### PR TITLE
fix: use absolute URL for OG and Twitter card images

### DIFF
--- a/new-branding/src/app/layout.tsx
+++ b/new-branding/src/app/layout.tsx
@@ -18,7 +18,7 @@ export const metadata: Metadata = {
     siteName: "Utexo",
     images: [
       {
-        url: "utexo-og.png",
+        url: "https://utexo.com/utexo-og.png",
         width: 1200,
         height: 630,
         alt: "Utexo - Private Stablecoin Payments on Bitcoin",
@@ -31,7 +31,7 @@ export const metadata: Metadata = {
     card: "summary_large_image",
     title: "Utexo - Move USDT Instantly and Privately on Bitcoin for Free",
     description: "APIs and products for private, instant payments on an open network. Move USDT for free on Bitcoin and Lightning, natively.",
-    images: ["utexo-og.png"],
+    images: ["https://utexo.com/utexo-og.png"],
     site: "@utexocom",
     creator: "@utexocom",
   },


### PR DESCRIPTION
## Summary
- OG image and Twitter card image URLs were relative (`utexo-og.png`), causing broken social previews
- Changed to absolute URLs (`https://utexo.com/utexo-og.png`) in `layout.tsx`

## Files changed
- `new-branding/src/app/layout.tsx` (2 lines)

## QA checklist
- [ ] Deploy to preview/staging
- [ ] Share staging URL in Slack — verify preview card shows image
- [ ] Share staging URL in Twitter composer — verify image renders
- [ ] Share staging URL in LinkedIn — verify image renders
- [ ] Check `/api-product` and `/cloud` pages also inherit correct OG image

## Risk
None — metadata only, no runtime behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)