### PR TITLE
fix(a11y): announce form validation errors to screen readers

### DIFF
--- a/new-branding/src/components/common/Input/index.tsx
+++ b/new-branding/src/components/common/Input/index.tsx
@@ -20,14 +20,15 @@ interface CommonInputProps {
 export const CommonInput = ({ title, placeholder, type = "text", field, error }: CommonInputProps) => {
   const generatedId = useId();
   const inputId = `input-${generatedId}`;
+  const errorId = `${inputId}-error`;
 
   return (
     <div className="common-input">
       {title && <label htmlFor={inputId} className="common-input__label">{title}</label>}
       <div className={`common-input__input-wrap ${error ? "common-input__input-wrap--error" : ""}`}>
-        <input {...field} id={inputId} type={type} placeholder={placeholder} className="common-input__field" />
+        <input {...field} id={inputId} type={type} placeholder={placeholder} className="common-input__field" aria-invalid={!!error} aria-describedby={error ? errorId : undefined} />
       </div>
-      <div className="common-input__error-slot">{error && <span className="common-input__error">{error.message}</span>}</div>
+      <div className="common-input__error-slot" aria-live="polite">{error && <span id={errorId} className="common-input__error" role="alert">{error.message}</span>}</div>
     </div>
   );
 };

--- a/new-branding/src/components/common/Select/index.tsx
+++ b/new-branding/src/components/common/Select/index.tsx
@@ -25,12 +25,13 @@ interface CommonSelectProps<T extends string = string> {
 export const CommonSelect = <T extends string = string>({ title, placeholder = "Select an option...", options, field, error }: CommonSelectProps<T>) => {
   const generatedId = useId();
   const selectId = `select-${generatedId}`;
+  const errorId = `${selectId}-error`;
 
   return (
     <div className="common-select">
       {title && <label htmlFor={selectId} className="common-select__label">{title}</label>}
-      <div className={`common-select__input-wrap ${error ? "contact-form__input-wrap--error" : ""}`}>
-        <select {...field} id={selectId} className="common-select__field">
+      <div className={`common-select__input-wrap ${error ? "common-select__input-wrap--error" : ""}`}>
+        <select {...field} id={selectId} className="common-select__field" aria-invalid={!!error} aria-describedby={error ? errorId : undefined}>
           <option value="" disabled hidden>
             {placeholder}
           </option>
@@ -46,7 +47,7 @@ export const CommonSelect = <T extends string = string>({ title, placeholder = "
           </svg>
         </span>
       </div>
-      <div className="common-select__error-slot">{error && <span className="common-select__error">{error.message}</span>}</div>
+      <div className="common-select__error-slot" aria-live="polite">{error && <span id={errorId} className="common-select__error" role="alert">{error.message}</span>}</div>
     </div>
   );
 };

--- a/new-branding/src/components/common/Textarea/index.tsx
+++ b/new-branding/src/components/common/Textarea/index.tsx
@@ -21,14 +21,15 @@ interface CommonTextareaProps {
 export const CommonTextarea = ({ title, placeholder, field, error, rows = 5, className }: CommonTextareaProps) => {
   const generatedId = useId();
   const textareaId = `textarea-${generatedId}`;
+  const errorId = `${textareaId}-error`;
 
   return (
     <div className={`common-textarea ${className ?? ""}`}>
       {title && <label htmlFor={textareaId} className="common-textarea__label">{title}</label>}
       <div className={`common-textarea__input-wrap ${error ? "common-textarea__input-wrap--error" : ""}`}>
-        <textarea {...field} id={textareaId} placeholder={placeholder} rows={rows} className="common-textarea__field" />
+        <textarea {...field} id={textareaId} placeholder={placeholder} rows={rows} className="common-textarea__field" aria-invalid={!!error} aria-describedby={error ? errorId : undefined} />
       </div>
-      <div className="common-textarea__error-slot">{error && <span className="common-textarea__error">{error.message}</span>}</div>
+      <div className="common-textarea__error-slot" aria-live="polite">{error && <span id={errorId} className="common-textarea__error" role="alert">{error.message}</span>}</div>
     </div>
   );
 };


### PR DESCRIPTION
## Summary
Screen readers were not announcing validation errors when they appeared on the contact form. Updated all three shared form primitives to properly communicate errors.

### Changes per component (Input, Select, Textarea):
- `aria-live="polite"` on the error slot container — tells screen readers to announce changes
- `role="alert"` on the error message span — ensures immediate announcement
- `aria-invalid` on the form control when errored — standard form error pattern
- `aria-describedby` linking the control to its error message — associates error with field

### Bonus fix
- Select component had wrong error class name (`contact-form__input-wrap--error` → `common-select__input-wrap--error`)

## Files changed
- `new-branding/src/components/common/Input/index.tsx`
- `new-branding/src/components/common/Select/index.tsx`
- `new-branding/src/components/common/Textarea/index.tsx`

## QA checklist
- [ ] Open `/contact-sales`
- [ ] Click Submit without filling required fields — verify error messages appear (visual unchanged)
- [ ] Fill in fields and resubmit — verify errors clear
- [ ] **With VoiceOver (Mac)**: Tab through form, trigger errors — verify they are announced
- [ ] Verify no layout shifts from added ARIA attributes
- [ ] Check Select error styling now applies correctly (was broken before due to wrong class name)

## Risk
None — ARIA attributes are invisible to sighted users. Only affects assistive technology.

🤖 Generated with [Claude Code](https://claude.com/claude-code)