### PR TITLE
fix(a11y): add meaningful alt text to slider icons and mark decorative images

### DIFF
--- a/new-branding/src/components/common/Products/index.tsx
+++ b/new-branding/src/components/common/Products/index.tsx
@@ -17,7 +17,7 @@ export const Products = () => {
         <div className="psp-products__card__info">
           <div className="psp-products__card__top">
             <div className="psp-products__card__icon">
-              <Image src="/psp/api-icon.svg" alt="" width={48} height={48} />
+              <Image src="/psp/api-icon.svg" alt="" width={48} height={48} aria-hidden="true" />
             </div>
             <div className="psp-products__card__content">
               <h3 className="psp-products__card__title">API</h3>

--- a/new-branding/src/components/common/Slider/index.tsx
+++ b/new-branding/src/components/common/Slider/index.tsx
@@ -73,7 +73,7 @@ export const Slider = ({ items }: SliderProps) => {
           {items.map(item => (
             <article key={item.id} className="carousel__slide">
               <div className="carousel__content">
-                <Image src={item.icon} alt="" width={160} height={40} className="carousel__icon" />
+                <Image src={item.icon} alt={`${item.title} logo`} width={160} height={40} className="carousel__icon" />
                 <h3 className="carousel__title">{item.title}</h3>
                 <p className="carousel__description">{item.description}</p>
                 <Link href={item.link} className="carousel__link">


### PR DESCRIPTION
## Summary
Improved screen reader experience for two components:

**Slider:** Carousel slide icons (partner/use-case logos) had `alt=""` — screen readers skipped them entirely. Changed to `alt="{title} logo"` so the logo is identified.

**Products:** API icon next to the "API" heading is decorative (heading already conveys meaning). Kept `alt=""` and added `aria-hidden="true"` to fully remove from the accessibility tree.

Arrow icons and background grid images are correctly decorative — no changes needed.

## Files changed
- `src/components/common/Slider/index.tsx` (1 line)
- `src/components/common/Products/index.tsx` (1 line)

## QA checklist
- [ ] Navigate to homepage carousel section — visual appearance unchanged
- [ ] With VoiceOver/NVDA: each carousel slide announces the partner logo name
- [ ] Navigate to products section — no duplicate "API" announcements from screen reader
- [ ] Verify no layout shifts or visual changes

## Risk
None — only ARIA/alt attributes changed. No visual impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)