### PR TITLE
security: harden rate limiter with cleanup and persistent email limiting

### DIFF
--- a/new-branding/src/app/api/contact/route.ts
+++ b/new-branding/src/app/api/contact/route.ts
@@ -58,6 +58,21 @@ export async function POST(req: Request) {
 
     const { fullName, email, companyName, jobTitle, companyType, useCase, volume, region, message, hearAbout } = parsed.data;
 
+    // Persistent rate limit: max 3 contact requests per email per hour
+    const oneHourAgo = new Date(Date.now() - 60 * 60 * 1000).toISOString();
+    const { count: recentCount } = await getSupabaseSrv()
+      .from("contact_requests")
+      .select("*", { count: "exact", head: true })
+      .eq("email", email)
+      .gte("created_at", oneHourAgo);
+
+    if (recentCount !== null && recentCount >= 3) {
+      return NextResponse.json(
+        { ok: false, error: "Too many requests from this email. Please try again later." },
+        { status: 429 },
+      );
+    }
+
     const user_agent = req.headers.get("user-agent") ?? null;
 
     const { error: insertErr } = await getSupabaseSrv().from("contact_requests").insert([

--- a/new-branding/src/lib/rateLimiter.ts
+++ b/new-branding/src/lib/rateLimiter.ts
@@ -1,14 +1,49 @@
+/**
+ * In-memory rate limiter with automatic cleanup.
+ *
+ * LIMITATION: On Vercel serverless, each function invocation may get
+ * its own memory space. This rate limiter only works within a single
+ * warm instance. For production-grade rate limiting, migrate to a
+ * persistent store (Upstash Redis, Vercel KV, or Supabase).
+ *
+ * This is a best-effort defense — the real protection comes from
+ * input validation and email sanitization in the route handlers.
+ */
+
 const rateLimitMap = new Map<string, { count: number; resetAt: number }>();
 
 export const RATE_LIMIT_MAX = 5;
 const RATE_LIMIT_WINDOW_MS = 60_000;
+const CLEANUP_INTERVAL_MS = 5 * 60_000; // Clean up every 5 minutes
+const MAX_ENTRIES = 10_000; // Hard cap to prevent memory exhaustion
 
-export function isRateLimited(ip: string): boolean {
+let lastCleanup = Date.now();
+
+function cleanup() {
   const now = Date.now();
-  const entry = rateLimitMap.get(ip);
+  if (now - lastCleanup < CLEANUP_INTERVAL_MS) return;
+  lastCleanup = now;
+
+  for (const [key, entry] of rateLimitMap) {
+    if (now > entry.resetAt) {
+      rateLimitMap.delete(key);
+    }
+  }
+}
+
+export function isRateLimited(key: string): boolean {
+  cleanup();
+
+  // Hard cap: if map is full, reject request (fail closed)
+  if (rateLimitMap.size >= MAX_ENTRIES && !rateLimitMap.has(key)) {
+    return true;
+  }
+
+  const now = Date.now();
+  const entry = rateLimitMap.get(key);
 
   if (!entry || now > entry.resetAt) {
-    rateLimitMap.set(ip, { count: 1, resetAt: now + RATE_LIMIT_WINDOW_MS });
+    rateLimitMap.set(key, { count: 1, resetAt: now + RATE_LIMIT_WINDOW_MS });
     return false;
   }
 


### PR DESCRIPTION
## Security Fix — HIGH

Closes #96

## Vulnerability
The in-memory rate limiter provided no real protection on Vercel serverless:
- State reset on every cold start/deployment
- Expired entries never cleaned up (memory leak)
- No cap on Map size (memory exhaustion vector)

## Fixes

### rateLimiter.ts (rewritten)
- **Automatic cleanup**: Expired entries pruned every 5 minutes
- **Hard cap**: 10,000 entries max — fails closed if exceeded (prevents memory exhaustion)
- **Documentation**: JSDoc explicitly documents the serverless limitation

### contact/route.ts (new persistent rate limit)
- Added **email-based rate limit**: max 3 contact requests per email per hour
- Checked via Supabase `count` query — works across all serverless instances
- This is the real protection layer — DB-backed, survives restarts

## Architecture note
The in-memory limiter is documented as **best-effort defense** (first line of defense within a warm instance). The persistent Supabase check is the actual enforcement. For full production-grade IP rate limiting, the team should evaluate Upstash Redis or Vercel KV.

## QA checklist
- [ ] Submit contact form 3 times with the same email — verify 4th is rejected with 429
- [ ] Submit contact form with different emails — verify each succeeds
- [ ] Submit signup form — verify still works (no changes to signup rate limiting)
- [ ] Wait 1 hour after hitting limit — verify email is unblocked

## Files changed
- `src/lib/rateLimiter.ts` (rewritten with cleanup + cap)
- `src/app/api/contact/route.ts` (added Supabase-backed email rate limit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)