### PR TITLE
fix(a11y): add reduced motion and webkit-playsinline to iGaming and retail wallet heroes

### DIFF
--- a/new-branding/src/components/igaming/Hero/index.tsx
+++ b/new-branding/src/components/igaming/Hero/index.tsx
@@ -2,12 +2,15 @@
 
 import { Tags } from "@/components/common/Tags";
 import { igamingHeroTags } from "@/mocks/igaming";
+import { useReducedMotionVideo } from "@/lib/hooks/useReduceMotion";
 import "./index.scss";
 
 export const IGamingHero = () => {
+  const videoRef = useReducedMotionVideo();
+
   return (
     <section className="igaming-hero">
-      <video className="igaming-hero__video" poster="/igaming/hero-image.png" autoPlay muted loop playsInline preload="auto">
+      <video className="igaming-hero__video" poster="/igaming/hero-image.png" autoPlay muted loop playsInline preload="auto" webkit-playsinline="true" ref={videoRef}>
         <source src="/igaming/igaming-video.webm" type="video/webm" />
         <source src="/igaming/igaming-video.mp4" type="video/mp4" />
       </video>

--- a/new-branding/src/components/retails-wallet/Hero/index.tsx
+++ b/new-branding/src/components/retails-wallet/Hero/index.tsx
@@ -2,13 +2,16 @@
 
 import { Tags } from "@/components/common/Tags";
 import { retailsWalletHeroTags } from "@/mocks/retailsWallets";
+import { useReducedMotionVideo } from "@/lib/hooks/useReduceMotion";
 
 import "./index.scss";
 
 export const RetailsWalletHero = () => {
+  const videoRef = useReducedMotionVideo();
+
   return (
     <section className="retails-wallet-hero">
-      <video className="retails-wallet-hero__video" poster="/igaming/hero-image.png" autoPlay muted loop playsInline preload="auto">
+      <video className="retails-wallet-hero__video" poster="/igaming/hero-image.png" autoPlay muted loop playsInline preload="auto" webkit-playsinline="true" ref={videoRef}>
         <source src="/retails-wallets/retails-hero.webm" type="video/webm" />
         <source src="/retails-wallets/retails-hero.mp4" type="video/mp4" />
       </video>


### PR DESCRIPTION
## Summary
- iGaming and retail wallet hero videos were missing the `useReducedMotionVideo` hook that all other heroes use (accessibility: respects `prefers-reduced-motion`)
- Both were also missing `webkit-playsinline="true"`, which prevents unwanted fullscreen on older iOS Safari

## Test plan
- [ ] Verify iGaming and retail wallet hero videos still autoplay normally
- [ ] Enable "Reduce motion" in OS accessibility settings — verify videos pause
- [ ] Test on iOS Safari — verify videos play inline, not fullscreen

🤖 Generated with [Claude Code](https://claude.com/claude-code)