### PR TITLE
perf: use preload=metadata for customer page hero videos

### DIFF
--- a/new-branding/src/components/custodians/Hero/index.tsx
+++ b/new-branding/src/components/custodians/Hero/index.tsx
@@ -11,7 +11,7 @@ export const CustodiansHero = () => {
 
   return (
     <section className="custodians-hero">
-      <video className="custodians-hero__video" poster="/custodians/custodains-hero.png" autoPlay muted loop playsInline preload="auto" webkit-playsinline="true" ref={videoRef}>
+      <video className="custodians-hero__video" poster="/custodians/custodains-hero.png" autoPlay muted loop playsInline preload="metadata" webkit-playsinline="true" ref={videoRef}>
         <source src="/custodians/custodains-hero.webm" type="video/webm" />
         <source src="/custodians/custodains-hero.mp4" type="video/mp4" />
       </video>

--- a/new-branding/src/components/enterprise-wallet/Hero/index.tsx
+++ b/new-branding/src/components/enterprise-wallet/Hero/index.tsx
@@ -11,7 +11,7 @@ export const EnterpriseWalletsHero = () => {
 
   return (
     <section className="enterprise-wallet-hero">
-      <video className="enterprise-wallet-hero__video" poster="/enterprise-wallet/enterprise-hero.png" autoPlay muted loop playsInline preload="auto" webkit-playsinline="true" ref={videoRef}>
+      <video className="enterprise-wallet-hero__video" poster="/enterprise-wallet/enterprise-hero.png" autoPlay muted loop playsInline preload="metadata" webkit-playsinline="true" ref={videoRef}>
         <source src="/enterprise-wallet/enterprise-hero.webm" type="video/webm" />
         <source src="/enterprise-wallet/enterprise-hero.mp4" type="video/mp4" />
       </video>

--- a/new-branding/src/components/exchange/Hero/index.tsx
+++ b/new-branding/src/components/exchange/Hero/index.tsx
@@ -11,7 +11,7 @@ export const ExchangeHero = () => {
 
   return (
     <section className="exchange-hero">
-      <video className="exchange-hero__video" poster="/exchanges/exchanges-hero.png" autoPlay muted loop playsInline preload="auto" webkit-playsinline="true" ref={videoRef}>
+      <video className="exchange-hero__video" poster="/exchanges/exchanges-hero.png" autoPlay muted loop playsInline preload="metadata" webkit-playsinline="true" ref={videoRef}>
         <source src="/exchanges/exchanges-hero.webm" type="video/webm" />
         <source src="/exchanges/exchanges-hero.webm" type="video/mp4" />
       </video>

--- a/new-branding/src/components/igaming/Hero/index.tsx
+++ b/new-branding/src/components/igaming/Hero/index.tsx
@@ -7,7 +7,7 @@ import "./index.scss";
 export const IGamingHero = () => {
   return (
     <section className="igaming-hero">
-      <video className="igaming-hero__video" poster="/igaming/hero-image.png" autoPlay muted loop playsInline preload="auto">
+      <video className="igaming-hero__video" poster="/igaming/hero-image.png" autoPlay muted loop playsInline preload="metadata">
         <source src="/igaming/igaming-video.webm" type="video/webm" />
         <source src="/igaming/igaming-video.mp4" type="video/mp4" />
       </video>

--- a/new-branding/src/components/retails-wallet/Hero/index.tsx
+++ b/new-branding/src/components/retails-wallet/Hero/index.tsx
@@ -8,7 +8,7 @@ import "./index.scss";
 export const RetailsWalletHero = () => {
   return (
     <section className="retails-wallet-hero">
-      <video className="retails-wallet-hero__video" poster="/igaming/hero-image.png" autoPlay muted loop playsInline preload="auto">
+      <video className="retails-wallet-hero__video" poster="/igaming/hero-image.png" autoPlay muted loop playsInline preload="metadata">
         <source src="/retails-wallets/retails-hero.webm" type="video/webm" />
         <source src="/retails-wallets/retails-hero.mp4" type="video/mp4" />
       </video>


### PR DESCRIPTION
## Summary
- All 5 customer page heroes (custodians, exchanges, enterprise wallet, iGaming, retail wallet) were using `preload="auto"`, eagerly downloading 5-7MB video files on page load
- Changed to `preload="metadata"` to match the home hero, so the poster image shows immediately while the video loads progressively

## Test plan
- [ ] Verify hero videos still autoplay on all 5 customer pages
- [ ] Check that poster image displays before video loads (throttle network in DevTools to observe)

🤖 Generated with [Claude Code](https://claude.com/claude-code)