### PR TITLE
fix(copy): correct preposition in AML compliance text

### DIFF
--- a/new-branding/src/mocks/api-product.tsx
+++ b/new-branding/src/mocks/api-product.tsx
@@ -12,7 +12,7 @@ export const apiFeature = [
     alt: "Easy API integration with existing tech stack",
   },
   {
-    text: "Stay compliant to AML requirements.",
+    text: "Stay compliant with AML requirements.",
     image: "/api-product/features/feature-2.svg",
     alt: "AML compliance built into payment flow",
   },


### PR DESCRIPTION
## Summary
- "Stay compliant to AML requirements" → "Stay compliant with AML requirements"
- "Compliant" takes the preposition "with", not "to" — standard English usage

## Location
- `src/mocks/api-product.tsx:16` (API features section)

🤖 Generated with [Claude Code](https://claude.com/claude-code)