### PR TITLE
fix(copy): correct "prefixed" to "pre-fixed" in exchange features

### DIFF
--- a/new-branding/src/mocks/exchange.ts
+++ b/new-branding/src/mocks/exchange.ts
@@ -5,7 +5,7 @@ export const exchangeFeatures: Feature[] = [
   {
     icon: "/common/features/expand.svg",
     title: "Expand USDT withdrawal options",
-    description: "Offer native USDT withdrawals on Lightning with prefixed fees and private execution.",
+    description: "Offer native USDT withdrawals on Lightning with pre-fixed fees and private execution.",
   },
   {
     icon: "/common/features/native.svg",


### PR DESCRIPTION
## Summary
- "prefixed fees" → "pre-fixed fees"
- "Prefixed" means "attached at the beginning" (like a word prefix). The intended meaning is "predetermined/locked-in costs"
- Aligns with the rest of the site which consistently uses "pre-fixed" or "fixed"

## Location
- `src/mocks/exchange.ts:8` (Exchange features section)

🤖 Generated with [Claude Code](https://claude.com/claude-code)