### PR TITLE
fix(copy): fix inconsistent capitalization in Cloud and product copy

### DIFF
--- a/new-branding/src/mocks/cloud.ts
+++ b/new-branding/src/mocks/cloud.ts
@@ -18,7 +18,7 @@ export const cloudOverviewFeatures: CloudOverviewFeature[] = [
   },
   {
     icon: "/cloud/overview/lifecycle.svg",
-    text: "Node Lifecycle management.",
+    text: "Node lifecycle management.",
   },
 ];
 

--- a/new-branding/src/mocks/common.tsx
+++ b/new-branding/src/mocks/common.tsx
@@ -31,7 +31,7 @@ export const apiProduct = {
 
 export const cloudProduct = {
   title: "Cloud",
-  subtitle: "One-Click Lightning network infrastructure.",
+  subtitle: "One-Click Lightning Network infrastructure.",
   description: "Managed Lightning infrastructure for running stablecoin payments and trading at scale, with built-in yield and zero operational overhead.",
   icon: { src: "/payments/cloud.svg" },
   links: [


### PR DESCRIPTION
## Summary
- "Node Lifecycle management" → "Node lifecycle management" — other items in the same list use sentence case; "Lifecycle" was inconsistently capitalized
- "Lightning network" → "Lightning Network" — "Lightning Network" is a proper noun and should always be capitalized

## Locations
- `src/mocks/cloud.ts:22`
- `src/mocks/common.tsx:34`

🤖 Generated with [Claude Code](https://claude.com/claude-code)