### PR TITLE
fix(typo): rename "enterpise" to "enterprise" in variable names

### DIFF
--- a/new-branding/src/app/enterprise-wallets/page.tsx
+++ b/new-branding/src/app/enterprise-wallets/page.tsx
@@ -3,7 +3,7 @@ import { Footer } from "@/components/common/Footer";
 import { TrustedBy } from "@/components/common/TrustedBy";
 import { Products } from "@/components/common/Products";
 import { FeaturesWrapper } from "@/components/common/Features/Wrapper";
-import { enterpiseWalletsFeatures } from "@/mocks/enterprise-wallets";
+import { enterpriseWalletsFeatures } from "@/mocks/enterprise-wallets";
 import { EnterpriseWalletsHero } from "@/components/enterprise-wallet/Hero";
 import { CloudInfo } from "@/components/common/CloudInfo";
 import { apiProduct, cloudProduct } from "@/mocks/common";
@@ -15,7 +15,7 @@ export default function EnterpriseWallets() {
       <div className="page__content">
         <EnterpriseWalletsHero />
         <TrustedBy />
-        <FeaturesWrapper features={enterpiseWalletsFeatures} />
+        <FeaturesWrapper features={enterpriseWalletsFeatures} />
         <Products products={[apiProduct, cloudProduct]} />
         <Footer />
       </div>

--- a/new-branding/src/components/enterprise-wallet/Hero/index.tsx
+++ b/new-branding/src/components/enterprise-wallet/Hero/index.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { Tags } from "@/components/common/Tags";
-import { enterpiseWalletsHeroTags } from "@/mocks/enterprise-wallets";
+import { enterpriseWalletsHeroTags } from "@/mocks/enterprise-wallets";
 import { useReducedMotionVideo } from "@/lib/hooks/useReduceMotion";
 
 import "./index.scss";
@@ -25,7 +25,7 @@ export const EnterpriseWalletsHero = () => {
 
           <p className="enterprise-wallet-hero__description">Enable Lightning-native BTC&lt;&gt;USDT settlement and yield without leaving your wallet.</p>
         </div>
-        <Tags tags={enterpiseWalletsHeroTags} />
+        <Tags tags={enterpriseWalletsHeroTags} />
       </div>
     </section>
   );

--- a/new-branding/src/mocks/enterprise-wallets.ts
+++ b/new-branding/src/mocks/enterprise-wallets.ts
@@ -1,7 +1,7 @@
 import { Feature } from "@/components/common/Features";
 
-export const enterpiseWalletsHeroTags = ["Off-exchange BTC/USDT transfers", "BTC/USDT yield from wallet", "Merchant & consumer payments", "PSPs settlement rails"];
-export const enterpiseWalletsFeatures: Feature[] = [
+export const enterpriseWalletsHeroTags = ["Off-exchange BTC/USDT transfers", "BTC/USDT yield from wallet", "Merchant & consumer payments", "PSPs settlement rails"];
+export const enterpriseWalletsFeatures: Feature[] = [
   {
     icon: "/common/features/dollar.svg",
     title: "Monetize BTC<>USDT volume",


### PR DESCRIPTION
## Summary
- `enterpiseWalletsHeroTags` → `enterpriseWalletsHeroTags`
- `enterpiseWalletsFeatures` → `enterpriseWalletsFeatures`
- Missing 'r' in "enterprise" across exported variable names and their imports

## Locations
- `src/mocks/enterprise-wallets.ts:3-4` (definitions)
- `src/app/enterprise-wallets/page.tsx:6` (import)
- `src/components/enterprise-wallet/Hero/index.tsx:4` (import)

🤖 Generated with [Claude Code](https://claude.com/claude-code)