### PR TITLE
fix: exchange hero mp4 source pointing to webm file

### DIFF
--- a/new-branding/src/components/exchange/Hero/index.tsx
+++ b/new-branding/src/components/exchange/Hero/index.tsx
@@ -13,7 +13,7 @@ export const ExchangeHero = () => {
     <section className="exchange-hero">
       <video className="exchange-hero__video" poster="/exchanges/exchanges-hero.png" autoPlay muted loop playsInline preload="auto" webkit-playsinline="true" ref={videoRef}>
         <source src="/exchanges/exchanges-hero.webm" type="video/webm" />
-        <source src="/exchanges/exchanges-hero.webm" type="video/mp4" />
+        <source src="/exchanges/exchanges-hero.mp4" type="video/mp4" />
       </video>
 
       <div className="exchange-hero__gradient" />


### PR DESCRIPTION
## Summary
- The mp4 fallback `<source>` in the exchange hero was pointing to the `.webm` file instead of `.mp4`
- Browsers without webm support would fail to play the hero video entirely

## Location
- `src/components/exchange/Hero/index.tsx:16`

## Test plan
- [ ] Verify exchange page hero video plays in Safari (mp4 fallback)
- [ ] Verify exchange page hero video plays in Chrome (webm primary)

🤖 Generated with [Claude Code](https://claude.com/claude-code)