### PR TITLE
fix: retail wallet hero using wrong poster image

### DIFF
--- a/new-branding/src/components/retails-wallet/Hero/index.tsx
+++ b/new-branding/src/components/retails-wallet/Hero/index.tsx
@@ -8,7 +8,7 @@ import "./index.scss";
 export const RetailsWalletHero = () => {
   return (
     <section className="retails-wallet-hero">
-      <video className="retails-wallet-hero__video" poster="/igaming/hero-image.png" autoPlay muted loop playsInline preload="auto">
+      <video className="retails-wallet-hero__video" poster="/retails-wallets/retails-hero.png" autoPlay muted loop playsInline preload="auto">
         <source src="/retails-wallets/retails-hero.webm" type="video/webm" />
         <source src="/retails-wallets/retails-hero.mp4" type="video/mp4" />
       </video>


### PR DESCRIPTION
## Summary
- Retail wallet hero was using the igaming poster image (`/igaming/hero-image.png`) instead of its own (`/retails-wallets/retails-hero.png`)

## Location
- `src/components/retails-wallet/Hero/index.tsx:11`

## Test plan
- [ ] Verify retail wallet page shows correct poster before video loads

🤖 Generated with [Claude Code](https://claude.com/claude-code)