### PR TITLE
fix(copy): fix capitalization and grammar in API product heading

### DIFF
--- a/new-branding/src/components/api-product/Operators/index.tsx
+++ b/new-branding/src/components/api-product/Operators/index.tsx
@@ -5,7 +5,7 @@ export const Operators = () => {
   return (
     <section className="operators">
       <h2 className="operators__title">
-        <span className="operators__title-accent">Best-in-class stablecoins</span> settlement Infrastructure
+        <span className="operators__title-accent">Best-in-class stablecoin</span> settlement infrastructure
       </h2>
 
       <div className="operators__grid">


### PR DESCRIPTION
## Summary
- "Best-in-class stablecoins settlement Infrastructure" → "Best-in-class stablecoin settlement infrastructure"
- "Infrastructure" was incorrectly capitalized mid-sentence
- "stablecoins" (plural noun) → "stablecoin" (adjective) for correct grammar

## Location
- `src/components/api-product/Operators/index.tsx:8`

🤖 Generated with [Claude Code](https://claude.com/claude-code)